### PR TITLE
Add RGB Matrix keycodes

### DIFF
--- a/keyboards/stm60/dp60/keymaps/hhkb_light_all_on/keymap.c
+++ b/keyboards/stm60/dp60/keymaps/hhkb_light_all_on/keymap.c
@@ -1,0 +1,20 @@
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [0] = LAYOUT_60_hhkb(
+    KC_ESC,   RGBM_TOG, RGBM_MOD, RGBM_HUI, RGBM_HUD, RGBM_SAI, RGBM_SAD, RGBM_VAI, RGBM_VAD, KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSLS,  KC_GRV,
+    KC_TAB,   RGB_TOG,  RGB_MOD,  RGB_HUI,  RGB_HUD,  RGB_SAI,  RGB_SAD,  RGB_VAI,  RGB_VAD,  KC_O,     KC_P,     KC_LBRC,  KC_RBRC,            KC_BSPC,
+    KC_LCTRL, KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,                      KC_ENT,
+    KC_LSFT,            KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,            KC_RSFT,  MO(1),
+              KC_LGUI,  KC_LALT,                                KC_SPC,                                 KC_RALT,  KC_RGUI
+  ),
+
+  [1] = LAYOUT_60_hhkb(
+    _______,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   _______,  KC_PSCR,
+    KC_CAPS,  RGB_TOG,  RGB_MOD,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  KC_UP,    _______,            KC_DEL,
+    _______,  KC_VOLD,  KC_VOLU,  KC_MUTE,  _______,  _______,  _______,  _______,  KC_HOME,  KC_PGUP,  KC_LEFT,  KC_RGHT,                      _______,
+    _______,            _______,  _______,  _______,  _______,  _______,  _______,  _______,  KC_END,   KC_PGDN,  KC_DOWN,            _______,  _______,
+              _______,  _______,                                _______,                                _______,  _______
+	),
+};

--- a/keyboards/stm60/dp60/keymaps/hhkb_light_all_on/rules.mk
+++ b/keyboards/stm60/dp60/keymaps/hhkb_light_all_on/rules.mk
@@ -1,0 +1,5 @@
+RGBLIGHT_ENABLE = yes        # Enable RGB bottom light
+RGB_MATRIX_ENABLE = yes      # Enable RGB matrix
+
+# Disable dynamic keymap because I usually uses qmk toolbox to flash keymaps
+DYNAMIC_KEYMAP_ENABLE = no

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -342,7 +342,7 @@ bool process_record_quantum(keyrecord_t *record) {
     }
     return false;
   #endif
-  #if defined(RGBLIGHT_ENABLE) || defined(RGB_MATRIX_ENABLE)
+  #if defined(RGBLIGHT_ENABLE)
   case RGB_TOG:
     // Split keyboards need to trigger on key-up for edge-case issue
     #ifndef SPLIT_KEYBOARD
@@ -536,7 +536,101 @@ bool process_record_quantum(keyrecord_t *record) {
     }
   #endif
     return false;
-  #endif // defined(RGBLIGHT_ENABLE) || defined(RGB_MATRIX_ENABLE)
+  #endif // defined(RGBLIGHT_ENABLE)
+  #if defined(RGB_MATRIX_ENABLE)
+  case RGB_MATRIX_TOG:
+    // Split keyboards need to trigger on key-up for edge-case issue
+    #ifndef SPLIT_KEYBOARD
+    if (record->event.pressed) {
+    #else
+    if (!record->event.pressed) {
+    #endif
+      rgb_matrix_toggle();
+    }
+    return false;
+  case RGB_MATRIX_MODE_FORWARD:
+    if (record->event.pressed) {
+      uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT));
+      if(shifted) {
+        rgb_matrix_step_reverse();
+      }
+      else {
+        rgb_matrix_step();
+      }
+    }
+    return false;
+  case RGB_MATRIX_MODE_REVERSE:
+    if (record->event.pressed) {
+      uint8_t shifted = get_mods() & (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT));
+      if(shifted) {
+        rgb_matrix_step();
+      }
+      else {
+        rgb_matrix_step_reverse();
+      }
+    }
+    return false;
+  case RGB_MATRIX_HUI:
+    // Split keyboards need to trigger on key-up for edge-case issue
+    #ifndef SPLIT_KEYBOARD
+    if (record->event.pressed) {
+    #else
+    if (!record->event.pressed) {
+    #endif
+      rgb_matrix_increase_hue();
+    }
+    return false;
+  case RGB_MATRIX_HUD:
+    // Split keyboards need to trigger on key-up for edge-case issue
+    #ifndef SPLIT_KEYBOARD
+    if (record->event.pressed) {
+    #else
+    if (!record->event.pressed) {
+    #endif
+      rgb_matrix_decrease_hue();
+    }
+    return false;
+  case RGB_MATRIX_SAI:
+    // Split keyboards need to trigger on key-up for edge-case issue
+    #ifndef SPLIT_KEYBOARD
+    if (record->event.pressed) {
+    #else
+    if (!record->event.pressed) {
+    #endif
+      rgb_matrix_increase_sat();
+    }
+    return false;
+  case RGB_MATRIX_SAD:
+    // Split keyboards need to trigger on key-up for edge-case issue
+    #ifndef SPLIT_KEYBOARD
+    if (record->event.pressed) {
+    #else
+    if (!record->event.pressed) {
+    #endif
+      rgb_matrix_decrease_sat();
+    }
+    return false;
+  case RGB_MATRIX_VAI:
+    // Split keyboards need to trigger on key-up for edge-case issue
+    #ifndef SPLIT_KEYBOARD
+    if (record->event.pressed) {
+    #else
+    if (!record->event.pressed) {
+    #endif
+      rgb_matrix_increase_val();
+    }
+    return false;
+  case RGB_MATRIX_VAD:
+    // Split keyboards need to trigger on key-up for edge-case issue
+    #ifndef SPLIT_KEYBOARD
+    if (record->event.pressed) {
+    #else
+    if (!record->event.pressed) {
+    #endif
+      rgb_matrix_decrease_val();
+    }
+    return false;
+  #endif // defined(RGB_MATRIX_ENABLE)
   #ifdef VELOCIKEY_ENABLE
     case VLK_TOG:
       if (record->event.pressed) {

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -424,6 +424,17 @@ enum quantum_keycodes {
     RGB_MODE_GRADIENT,
     RGB_MODE_RGBTEST,
 
+    // RGM Matrix functionality
+    RGB_MATRIX_TOG,
+    RGB_MATRIX_MODE_FORWARD,
+    RGB_MATRIX_MODE_REVERSE,
+    RGB_MATRIX_HUI,
+    RGB_MATRIX_HUD,
+    RGB_MATRIX_SAI,
+    RGB_MATRIX_SAD,
+    RGB_MATRIX_VAI,
+    RGB_MATRIX_VAD,
+
     //Momentum matching toggle
     VLK_TOG,
 
@@ -628,6 +639,16 @@ enum quantum_keycodes {
 #define RGB_M_X RGB_MODE_XMAS
 #define RGB_M_G RGB_MODE_GRADIENT
 #define RGB_M_T RGB_MODE_RGBTEST
+
+#define RGBM_TOG RGB_MATRIX_TOG
+#define RGBM_MOD RGB_MATRIX_MODE_FORWARD
+#define RGBM_RMOD RGB_MATRIX_MODE_REVERSE
+#define RGBM_HUI RGB_MATRIX_HUI
+#define RGBM_HUD RGB_MATRIX_HUD
+#define RGBM_SAI RGB_MATRIX_SAI
+#define RGBM_SAD RGB_MATRIX_SAD
+#define RGBM_VAI RGB_MATRIX_VAI
+#define RGBM_VAD RGB_MATRIX_VAD
 
 // L-ayer, T-ap - 256 keycode max, 16 layer max
 #define LT(layer, kc) (QK_LAYER_TAP | (((layer) & 0xF) << 8) | ((kc) & 0xFF))

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -58,12 +58,12 @@
 // -----End rgb effect includes macros-------
 // ------------------------------------------
 
-#ifndef RGB_DISABLE_AFTER_TIMEOUT
-  #define RGB_DISABLE_AFTER_TIMEOUT 0
+#ifndef RGB_MATRIX_DISABLE_AFTER_TIME
+  #define RGB_MATRIX_DISABLE_AFTER_TIME 0
 #endif
 
-#ifndef RGB_DISABLE_WHEN_USB_SUSPENDED
-  #define RGB_DISABLE_WHEN_USB_SUSPENDED false
+#ifndef RGB_MATRIX_DISABLE_WHEN_USB_SUSPENDED
+  #define RGB_MATRIX_DISABLE_WHEN_USB_SUSPENDED false
 #endif
 
 #ifndef EECONFIG_RGB_MATRIX
@@ -376,7 +376,7 @@ void rgb_matrix_task(void) {
 
   // Ideally we would also stop sending zeros to the LED driver PWM buffers
   // while suspended and just do a software shutdown. This is a cheap hack for now.
-  bool suspend_backlight = ((g_suspend_state && RGB_DISABLE_WHEN_USB_SUSPENDED) || (RGB_DISABLE_AFTER_TIMEOUT > 0 && g_rgb_counters.any_key_hit > RGB_DISABLE_AFTER_TIMEOUT * 60 * 20));
+  bool suspend_backlight = ((g_suspend_state && RGB_MATRIX_DISABLE_WHEN_USB_SUSPENDED) || (RGB_MATRIX_DISABLE_AFTER_TIME > 0 && g_rgb_counters.any_key_hit > RGB_MATRIX_DISABLE_AFTER_TIME * 60 * 20));
   uint8_t effect = suspend_backlight || !rgb_matrix_config.enable ? 0 : rgb_matrix_config.mode;
 
   switch (rgb_task_state) {


### PR DESCRIPTION
Hi Yu,

This PR adds keycodes for RGB Matrix. 

Using the added keycodes, we could turn on and manipulate both RGB light(bottom) and RGB matrix(top) of dp60 pcb at the same time. All added keycodes(prefixed by `RGBM_`) and their corresponding keycodes for RGB light(prefixed by `RGB_`) are tested working fine.

Refer to the directory `keymaps/hhkb_light_all_on` for an example.

Cheers.
